### PR TITLE
feat: add previousOpenings.md

### DIFF
--- a/onboarding_docs/docs/SectionII/previousOpenings.md
+++ b/onboarding_docs/docs/SectionII/previousOpenings.md
@@ -1,0 +1,8 @@
+## Previous Openings
+
+##### _Closed_: 09/14
+- [Examples Initiative Mentee](https://nodejs.medium.com/announcing-new-node-js-mentorship-opportunity-c3d3cc200b3d)
+
+
+##### _Closed_: 05/15
+- [Mentorship Initiative](https://nodejs.aidaform.com/mentorship-team-application)


### PR DESCRIPTION
Creates `previousOpenings.md` to serve as a reference of previous mentee openings.
This includes the date the opening was closed with a link to the opening's blog post.