### PR TITLE
Link directly to deployed onboarding doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Stay in touch with the mentorship program and receive the latest updates:
 
 ## Onboarding Documentation
 
-For more information on Mentor and Mentee expectations, see the Onboarding Doc [README.md](onboarding_docs/README.md)
+For more information on Mentor and Mentee expectations, see the [Onboarding Doc](https://nodejs.github.io/mentorship/onboarding/).
 
 ## Node.js Mentorship Initiative Members
 


### PR DESCRIPTION
Currently, the README points to another part of the repo, but mentors and mentees who come to our repo would benefit from seeing the deployed Onboarding Doc.