### PR TITLE
chore: update honkit to 3.16.17

### DIFF
--- a/onboarding_docs/package-lock.json
+++ b/onboarding_docs/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "honkit": "^3.6.16"
+        "honkit": "^3.6.17"
       }
     },
     "node_modules/@asciidoctor/cli": {
@@ -48,12 +48,12 @@
       }
     },
     "node_modules/@honkit/asciidoc": {
-      "version": "3.6.16",
-      "resolved": "https://registry.npmjs.org/@honkit/asciidoc/-/asciidoc-3.6.16.tgz",
-      "integrity": "sha512-BqsYe4L+/pvtxEcXwM7XVC8sB/n2+ceIJfmP4DGkvanMyEhhibo0QoU5L2sTz9QTMHTaPDoi8+IJN5u7Z5BZcQ==",
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/@honkit/asciidoc/-/asciidoc-3.6.17.tgz",
+      "integrity": "sha512-YUkJTghC9BRbFGSjd1cAyyq9YtJeSdLkgt9XUHeokmU5rkwN2KUg5Je5OZ2hxD5U8Cp48YbG6bUCo3zvX2AIxA==",
       "dev": true,
       "dependencies": {
-        "@honkit/html": "^3.6.16",
+        "@honkit/html": "^3.6.17",
         "asciidoctor": "^2.2.0",
         "lodash": "^4.13.1"
       }
@@ -71,18 +71,18 @@
       }
     },
     "node_modules/@honkit/honkit-plugin-theme-default": {
-      "version": "3.6.16",
-      "resolved": "https://registry.npmjs.org/@honkit/honkit-plugin-theme-default/-/honkit-plugin-theme-default-3.6.16.tgz",
-      "integrity": "sha512-a5EpdhQMtx9g8L2VuATYeB1GsXWDJ4EEClsv5aRHjRiABOUD+VolE4uSAVDpyN2agHz52Bmot7fqn0b5KDuc9A==",
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/@honkit/honkit-plugin-theme-default/-/honkit-plugin-theme-default-3.6.17.tgz",
+      "integrity": "sha512-d1CKAWPZ9JqngjnxoXsak/Zgk4+BmalPkG1UrfYl2jnkAz+I5g8gZAuDyk9lTH1lL+y7ndsDvVLM4GviymfxFA==",
       "dev": true,
       "engines": {
         "gitbook": ">=3.0.0"
       }
     },
     "node_modules/@honkit/html": {
-      "version": "3.6.16",
-      "resolved": "https://registry.npmjs.org/@honkit/html/-/html-3.6.16.tgz",
-      "integrity": "sha512-hsb4BiYwrwWBJLW/zcgpA2J6NQdSUUIBIUBSco7pUZt9wrGC5agQF8MciUFJLA9v8IoRKFYL4olXF4EDzAk9jg==",
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/@honkit/html/-/html-3.6.17.tgz",
+      "integrity": "sha512-EXCPwcr6KOVueRppzpAolKiUpO+BUuRHw2F22U/R+R7MPwmtqdlq9XYg+H/51yIBXFX3bPAz672Ce/tc58p++g==",
       "dev": true,
       "dependencies": {
         "cheerio": "^0.20.0",
@@ -91,12 +91,12 @@
       }
     },
     "node_modules/@honkit/markdown-legacy": {
-      "version": "3.6.16",
-      "resolved": "https://registry.npmjs.org/@honkit/markdown-legacy/-/markdown-legacy-3.6.16.tgz",
-      "integrity": "sha512-OxCxsCEusgBH1n6rLZxUBGpfY6KyCkpSzfvPek8xiWeYOLR2BIHSeiHVgjw8wikvykwkd9GdLveNTdDvs3UE8w==",
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/@honkit/markdown-legacy/-/markdown-legacy-3.6.17.tgz",
+      "integrity": "sha512-4/ldE1IHnYSxtz7WikHVdEjvbZNq2mdHqldEa0HCo9BAZIf2Wvw93i3rQg4Rk0G2G12h6U0mSSBUwR1fu0dAhA==",
       "dev": true,
       "dependencies": {
-        "@honkit/html": "^3.6.16",
+        "@honkit/html": "^3.6.17",
         "kramed": "0.5.6",
         "lodash": "^4.13.1"
       }
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/binary-extensions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -464,14 +464,14 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
       "dev": true,
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -482,7 +482,7 @@
         "node": ">= 8.10.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.1.2"
+        "fsevents": "~2.3.1"
       }
     },
     "node_modules/cliui": {
@@ -606,15 +606,6 @@
       },
       "engines": {
         "node": ">=4.8"
-      }
-    },
-    "node_modules/cross-spawn/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/cross-spawn/node_modules/which": {
@@ -785,19 +776,19 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "dev": true,
       "dependencies": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
       }
     },
     "node_modules/domelementtype": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-      "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "node_modules/domhandler": {
@@ -1101,10 +1092,9 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "deprecated": "Please update to v 2.2.x",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -1114,6 +1104,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -1219,9 +1215,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
     "node_modules/har-schema": {
@@ -1247,6 +1243,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1257,73 +1265,73 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
-      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
+      "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ==",
       "dev": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/honkit": {
-      "version": "3.6.16",
-      "resolved": "https://registry.npmjs.org/honkit/-/honkit-3.6.16.tgz",
-      "integrity": "sha512-TtJDqY5o8SEHp7hvD9icTamuIdSNw2NDWMq2xyklhyqtxd/ImbyHDDOk8MVLVbcWj+DFlc/Vq3Yjv3cwV1/VUQ==",
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/honkit/-/honkit-3.6.17.tgz",
+      "integrity": "sha512-sTo0iVHdCv5Z8Yi7IHk4Zyoa5eSMqim4bTadA4Y6DN1Fjxt1XJH4Hkk5m44gs3JN8j/eAW58cF7N2EYYkSRluA==",
       "dev": true,
       "dependencies": {
-        "@honkit/asciidoc": "^3.6.16",
+        "@honkit/asciidoc": "^3.6.17",
         "@honkit/honkit-plugin-highlight": "^3.6.16",
-        "@honkit/honkit-plugin-theme-default": "^3.6.16",
-        "@honkit/markdown-legacy": "^3.6.16",
-        "bash-color": "0.0.4",
+        "@honkit/honkit-plugin-theme-default": "^3.6.17",
+        "@honkit/markdown-legacy": "^3.6.17",
+        "bash-color": "^0.0.4",
         "cheerio": "^0.20.0",
         "chokidar": "^3.3.0",
         "commander": "^5.1.0",
-        "cp": "0.2.0",
-        "cpr": "3.0.1",
-        "crc": "3.8.0",
-        "destroy": "1.0.4",
-        "direction": "0.1.5",
-        "dom-serializer": "0.1.0",
+        "cp": "^0.2.0",
+        "cpr": "^3.0.1",
+        "crc": "^3.8.0",
+        "destroy": "^1.0.4",
+        "direction": "^0.1.5",
+        "dom-serializer": "^0.1.0",
         "error": "7.0.2",
         "escape-html": "^1.0.3",
-        "escape-string-regexp": "4.0.0",
+        "escape-string-regexp": "^4.0.0",
         "extend": "^3.0.0",
         "flat-cache": "^2.0.1",
         "front-matter": "^2.1.0",
         "gitbook-plugin-fontsettings": "^2.0.0",
-        "gitbook-plugin-livereload": "0.0.1",
+        "gitbook-plugin-livereload": "^0.0.1",
         "gitbook-plugin-lunr": "^1.2.0",
         "gitbook-plugin-search": "^2.2.1",
-        "github-slugid": "1.0.1",
+        "github-slugid": "^1.0.1",
         "global-npm": "^0.4.0",
-        "i18n-t": "1.0.1",
-        "ignore": "5.1.8",
+        "i18n-t": "^1.0.1",
+        "ignore": "^5.1.8",
         "immutable": "^3.8.1",
         "is": "^3.1.0",
         "js-yaml": "^3.6.1",
-        "json-schema-defaults": "0.1.1",
+        "json-schema-defaults": "^0.1.1",
         "jsonschema": "1.1.0",
         "juice": "^6.0.0",
         "memoize-one": "^5.1.1",
-        "mkdirp": "1.0.4",
+        "mkdirp": "^1.0.4",
         "moment": "^2.24.0",
         "nunjucks": "^3.2.0",
-        "nunjucks-do": "1.0.0",
+        "nunjucks-do": "^1.0.0",
         "object-path": "^0.11.5",
         "omit-keys": "^0.1.0",
         "open": "^7.0.0",
-        "q": "1.5.1",
+        "q": "^1.5.1",
         "read-installed": "^4.0.3",
         "request": "^2.88.0",
-        "resolve": "1.17.0",
-        "semver": "5.1.0",
+        "resolve": "^1.17.0",
+        "semver": "^5.1.0",
         "send": "^0.17.1",
         "spawn-cmd": "0.0.2",
         "tiny-lr": "^1.1.1",
         "tmp": "0.0.28",
         "try-resolve": "^1.0.1",
-        "urijs": "1.18.0"
+        "urijs": "^1.19.6"
       },
       "bin": {
         "honkit": "bin/honkit.js"
@@ -1380,9 +1388,9 @@
       }
     },
     "node_modules/http-parser-js": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.2.tgz",
-      "integrity": "sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
       "dev": true
     },
     "node_modules/http-signature": {
@@ -1494,6 +1502,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-docker": {
@@ -1746,12 +1766,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
-    "node_modules/juice/node_modules/domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
-    },
     "node_modules/juice/node_modules/htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -1945,21 +1959,21 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "dev": true,
       "dependencies": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.45.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -2160,9 +2174,9 @@
       }
     },
     "node_modules/open": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.3.0.tgz",
-      "integrity": "sha512-mgLwQIx2F/ye9SmbrUkurZCnkoXyXyu9EbHtJZrICjVAJfyMArdHp3KkixGdZx1ZHFPNIwl0DDM1dFFqXbTLZw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.1.tgz",
+      "integrity": "sha512-Pxv+fKRsd/Ozflgn2Gjev1HZveJJeKR6hKKmdaImJMuEZ6htAvCTbcMABJo+qevlAelTLCrEK3YTKZ9fVTcSPw==",
       "dev": true,
       "dependencies": {
         "is-docker": "^2.0.0",
@@ -2476,11 +2490,12 @@
       "dev": true
     },
     "node_modules/resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "dependencies": {
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       },
       "funding": {
@@ -2539,9 +2554,9 @@
       "optional": true
     },
     "node_modules/semver": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-      "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -2890,18 +2905,18 @@
       }
     },
     "node_modules/uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
     },
     "node_modules/urijs": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.18.0.tgz",
-      "integrity": "sha1-CRy7f21gQBsuXjXFegQXe5u9EvI=",
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
+      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw==",
       "dev": true
     },
     "node_modules/util-deprecate": {
@@ -3064,9 +3079,9 @@
       }
     },
     "node_modules/web-resource-inliner/node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -3311,12 +3326,12 @@
       }
     },
     "@honkit/asciidoc": {
-      "version": "3.6.16",
-      "resolved": "https://registry.npmjs.org/@honkit/asciidoc/-/asciidoc-3.6.16.tgz",
-      "integrity": "sha512-BqsYe4L+/pvtxEcXwM7XVC8sB/n2+ceIJfmP4DGkvanMyEhhibo0QoU5L2sTz9QTMHTaPDoi8+IJN5u7Z5BZcQ==",
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/@honkit/asciidoc/-/asciidoc-3.6.17.tgz",
+      "integrity": "sha512-YUkJTghC9BRbFGSjd1cAyyq9YtJeSdLkgt9XUHeokmU5rkwN2KUg5Je5OZ2hxD5U8Cp48YbG6bUCo3zvX2AIxA==",
       "dev": true,
       "requires": {
-        "@honkit/html": "^3.6.16",
+        "@honkit/html": "^3.6.17",
         "asciidoctor": "^2.2.0",
         "lodash": "^4.13.1"
       }
@@ -3331,15 +3346,15 @@
       }
     },
     "@honkit/honkit-plugin-theme-default": {
-      "version": "3.6.16",
-      "resolved": "https://registry.npmjs.org/@honkit/honkit-plugin-theme-default/-/honkit-plugin-theme-default-3.6.16.tgz",
-      "integrity": "sha512-a5EpdhQMtx9g8L2VuATYeB1GsXWDJ4EEClsv5aRHjRiABOUD+VolE4uSAVDpyN2agHz52Bmot7fqn0b5KDuc9A==",
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/@honkit/honkit-plugin-theme-default/-/honkit-plugin-theme-default-3.6.17.tgz",
+      "integrity": "sha512-d1CKAWPZ9JqngjnxoXsak/Zgk4+BmalPkG1UrfYl2jnkAz+I5g8gZAuDyk9lTH1lL+y7ndsDvVLM4GviymfxFA==",
       "dev": true
     },
     "@honkit/html": {
-      "version": "3.6.16",
-      "resolved": "https://registry.npmjs.org/@honkit/html/-/html-3.6.16.tgz",
-      "integrity": "sha512-hsb4BiYwrwWBJLW/zcgpA2J6NQdSUUIBIUBSco7pUZt9wrGC5agQF8MciUFJLA9v8IoRKFYL4olXF4EDzAk9jg==",
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/@honkit/html/-/html-3.6.17.tgz",
+      "integrity": "sha512-EXCPwcr6KOVueRppzpAolKiUpO+BUuRHw2F22U/R+R7MPwmtqdlq9XYg+H/51yIBXFX3bPAz672Ce/tc58p++g==",
       "dev": true,
       "requires": {
         "cheerio": "^0.20.0",
@@ -3348,12 +3363,12 @@
       }
     },
     "@honkit/markdown-legacy": {
-      "version": "3.6.16",
-      "resolved": "https://registry.npmjs.org/@honkit/markdown-legacy/-/markdown-legacy-3.6.16.tgz",
-      "integrity": "sha512-OxCxsCEusgBH1n6rLZxUBGpfY6KyCkpSzfvPek8xiWeYOLR2BIHSeiHVgjw8wikvykwkd9GdLveNTdDvs3UE8w==",
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/@honkit/markdown-legacy/-/markdown-legacy-3.6.17.tgz",
+      "integrity": "sha512-4/ldE1IHnYSxtz7WikHVdEjvbZNq2mdHqldEa0HCo9BAZIf2Wvw93i3rQg4Rk0G2G12h6U0mSSBUwR1fu0dAhA==",
       "dev": true,
       "requires": {
-        "@honkit/html": "^3.6.16",
+        "@honkit/html": "^3.6.17",
         "kramed": "0.5.6",
         "lodash": "^4.13.1"
       }
@@ -3533,9 +3548,9 @@
       }
     },
     "binary-extensions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
     "body": {
@@ -3637,14 +3652,14 @@
       }
     },
     "chokidar": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3762,12 +3777,6 @@
         "which": "^1.2.9"
       },
       "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
         "which": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -3910,19 +3919,19 @@
       "dev": true
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
       }
     },
     "domelementtype": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-      "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "domhandler": {
@@ -4166,11 +4175,17 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -4255,9 +4270,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
     },
     "har-schema": {
@@ -4276,6 +4291,15 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -4283,70 +4307,70 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
-      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
+      "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ==",
       "dev": true
     },
     "honkit": {
-      "version": "3.6.16",
-      "resolved": "https://registry.npmjs.org/honkit/-/honkit-3.6.16.tgz",
-      "integrity": "sha512-TtJDqY5o8SEHp7hvD9icTamuIdSNw2NDWMq2xyklhyqtxd/ImbyHDDOk8MVLVbcWj+DFlc/Vq3Yjv3cwV1/VUQ==",
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/honkit/-/honkit-3.6.17.tgz",
+      "integrity": "sha512-sTo0iVHdCv5Z8Yi7IHk4Zyoa5eSMqim4bTadA4Y6DN1Fjxt1XJH4Hkk5m44gs3JN8j/eAW58cF7N2EYYkSRluA==",
       "dev": true,
       "requires": {
-        "@honkit/asciidoc": "^3.6.16",
+        "@honkit/asciidoc": "^3.6.17",
         "@honkit/honkit-plugin-highlight": "^3.6.16",
-        "@honkit/honkit-plugin-theme-default": "^3.6.16",
-        "@honkit/markdown-legacy": "^3.6.16",
-        "bash-color": "0.0.4",
+        "@honkit/honkit-plugin-theme-default": "^3.6.17",
+        "@honkit/markdown-legacy": "^3.6.17",
+        "bash-color": "^0.0.4",
         "cheerio": "^0.20.0",
         "chokidar": "^3.3.0",
         "commander": "^5.1.0",
-        "cp": "0.2.0",
-        "cpr": "3.0.1",
-        "crc": "3.8.0",
-        "destroy": "1.0.4",
-        "direction": "0.1.5",
-        "dom-serializer": "0.1.0",
+        "cp": "^0.2.0",
+        "cpr": "^3.0.1",
+        "crc": "^3.8.0",
+        "destroy": "^1.0.4",
+        "direction": "^0.1.5",
+        "dom-serializer": "^0.1.0",
         "error": "7.0.2",
         "escape-html": "^1.0.3",
-        "escape-string-regexp": "4.0.0",
+        "escape-string-regexp": "^4.0.0",
         "extend": "^3.0.0",
         "flat-cache": "^2.0.1",
         "front-matter": "^2.1.0",
         "gitbook-plugin-fontsettings": "^2.0.0",
-        "gitbook-plugin-livereload": "0.0.1",
+        "gitbook-plugin-livereload": "^0.0.1",
         "gitbook-plugin-lunr": "^1.2.0",
         "gitbook-plugin-search": "^2.2.1",
-        "github-slugid": "1.0.1",
+        "github-slugid": "^1.0.1",
         "global-npm": "^0.4.0",
-        "i18n-t": "1.0.1",
-        "ignore": "5.1.8",
+        "i18n-t": "^1.0.1",
+        "ignore": "^5.1.8",
         "immutable": "^3.8.1",
         "is": "^3.1.0",
         "js-yaml": "^3.6.1",
-        "json-schema-defaults": "0.1.1",
+        "json-schema-defaults": "^0.1.1",
         "jsonschema": "1.1.0",
         "juice": "^6.0.0",
         "memoize-one": "^5.1.1",
-        "mkdirp": "1.0.4",
+        "mkdirp": "^1.0.4",
         "moment": "^2.24.0",
         "nunjucks": "^3.2.0",
-        "nunjucks-do": "1.0.0",
+        "nunjucks-do": "^1.0.0",
         "object-path": "^0.11.5",
         "omit-keys": "^0.1.0",
         "open": "^7.0.0",
-        "q": "1.5.1",
+        "q": "^1.5.1",
         "read-installed": "^4.0.3",
         "request": "^2.88.0",
-        "resolve": "1.17.0",
-        "semver": "5.1.0",
+        "resolve": "^1.17.0",
+        "semver": "^5.1.0",
         "send": "^0.17.1",
         "spawn-cmd": "0.0.2",
         "tiny-lr": "^1.1.1",
         "tmp": "0.0.28",
         "try-resolve": "^1.0.1",
-        "urijs": "1.18.0"
+        "urijs": "^1.19.6"
       }
     },
     "hosted-git-info": {
@@ -4396,9 +4420,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.2.tgz",
-      "integrity": "sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
       "dev": true
     },
     "http-signature": {
@@ -4474,6 +4498,15 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-docker": {
@@ -4681,12 +4714,6 @@
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         },
-        "domelementtype": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-          "dev": true
-        },
         "htmlparser2": {
           "version": "3.10.1",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -4864,18 +4891,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.45.0"
       }
     },
     "mimer": {
@@ -5028,9 +5055,9 @@
       }
     },
     "open": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.3.0.tgz",
-      "integrity": "sha512-mgLwQIx2F/ye9SmbrUkurZCnkoXyXyu9EbHtJZrICjVAJfyMArdHp3KkixGdZx1ZHFPNIwl0DDM1dFFqXbTLZw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.1.tgz",
+      "integrity": "sha512-Pxv+fKRsd/Ozflgn2Gjev1HZveJJeKR6hKKmdaImJMuEZ6htAvCTbcMABJo+qevlAelTLCrEK3YTKZ9fVTcSPw==",
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0",
@@ -5273,11 +5300,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -5316,9 +5344,9 @@
       "optional": true
     },
     "semver": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-      "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "send": {
@@ -5607,18 +5635,18 @@
       "dev": true
     },
     "uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
     },
     "urijs": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.18.0.tgz",
-      "integrity": "sha1-CRy7f21gQBsuXjXFegQXe5u9EvI=",
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
+      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw==",
       "dev": true
     },
     "util-deprecate": {
@@ -5743,9 +5771,9 @@
           }
         },
         "entities": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
           "dev": true
         },
         "htmlparser2": {

--- a/onboarding_docs/package.json
+++ b/onboarding_docs/package.json
@@ -19,6 +19,6 @@
   },
   "homepage": "https://github.com/nodejs/mentorship",
   "devDependencies": {
-    "honkit": "^3.6.16"
+    "honkit": "^3.6.17"
   }
 }


### PR DESCRIPTION
This also updates the urijs dependency of honkit to 1.19.x. It will thus
resolve a security alert in the GitHub interface.